### PR TITLE
50 - Develop locally without requiring local backend

### DIFF
--- a/src/envEndpoints.json
+++ b/src/envEndpoints.json
@@ -1,0 +1,5 @@
+{
+  "LOCAL_API_URL": "http://localhost:4000/graphql",
+  "PROD_API_URL": "http://35.192.24.65/graphql",
+  "USE_PROD_ENDPOINT": true
+}

--- a/src/relayEnv.js
+++ b/src/relayEnv.js
@@ -4,7 +4,7 @@ const {
   RecordSource,
   Store,
 } = require('relay-runtime');
-const { API_URL } = require('./config.json');
+const { LOCAL_API_URL, PROD_API_URL, USE_PROD_ENDPOINT } = require('./envEndpoints.json');
 
 // Define a function that fetches the results of an operation (query/mutation/etc)
 // and returns its results as a Promise:
@@ -14,7 +14,7 @@ function fetchQuery(
   // cacheConfig,
   // uploadables,
 ) {
-  return fetch(API_URL || 'http://localhost:4000/graphql', {
+  return fetch(USE_PROD_ENDPOINT ? PROD_API_URL : LOCAL_API_URL, {
     method: 'POST',
     headers: {
       // Add authentication and other headers here


### PR DESCRIPTION
This makes onboarding new members a lot easier as they won't have to set
up the entire backend.

This will work by using the Prod API (already publicly accessible)
instead of the local endpoint by default. This means that it'll be set
to Prod by default.

https://github.com/trynmaps/tryn-react/issues/50