### PR TITLE
Fixes display of K/T line

### DIFF
--- a/src/Map.jsx
+++ b/src/Map.jsx
@@ -266,21 +266,19 @@ class Map extends Component {
     const subRouteLayer = subroute && getSubRoutesLayer(subroute);
     // I don't know what settings used for,
     // just keeping it in following format to bypass linter errors
+
+    // selectedRouteNames comes from GeoJSON file
     const selectedRouteNames = new Set();
     this.selectedRoutes
       .forEach(route => selectedRouteNames.add(route.properties.name));
-    const selectedRouteDict = {};
-    selectedRouteNames
-      .forEach((name) => {
-        if (name === 'K/T') {
-          // eslint-disable-next-line dot-notation
-          selectedRouteDict['KT'] = name;
-        } else {
-          selectedRouteDict[name] = name;
-        }
-      });
+    // maps API route name to GeoJSON route name
+    const routeNameMapping = {
+      KT: 'K/T',
+    };
+    // eslint-disable-next-line no-console
+    console.log(selectedRouteNames);
     const routeLayers = (routes || [])
-      .filter(route => selectedRouteDict[route.rid])
+      .filter(route => selectedRouteNames.has(routeNameMapping[route.rid] || route.rid))
       .reduce((layers, route) => [
         ...layers,
         this.state.showStops
@@ -292,6 +290,8 @@ class Map extends Component {
         subRouteLayer,
         ...getVehicleMarkersLayer(route, info => this.displayVehicleInfo(info)),
       ], []);
+    // eslint-disable-next-line no-console
+    console.log(routeLayers);
     routeLayers.push(getRoutesLayer(geojson));
     return (
       <ReactMapGL

--- a/src/Map.jsx
+++ b/src/Map.jsx
@@ -266,12 +266,21 @@ class Map extends Component {
     const subRouteLayer = subroute && getSubRoutesLayer(subroute);
     // I don't know what settings used for,
     // just keeping it in following format to bypass linter errors
-
     const selectedRouteNames = new Set();
     this.selectedRoutes
-      .forEach(route => selectedRouteNames.add(route.properties.name.replace(/[.,/#!$%^&*;:{}=\-_`~()]/g, '')));
+      .forEach(route => selectedRouteNames.add(route.properties.name));
+    const selectedRouteDict = {};
+    selectedRouteNames
+      .forEach((name) => {
+        if (name === 'K/T') {
+          // eslint-disable-next-line dot-notation
+          selectedRouteDict['KT'] = name;
+        } else {
+          selectedRouteDict[name] = name;
+        }
+      });
     const routeLayers = (routes || [])
-      .filter(route => selectedRouteNames.has(route.rid))
+      .filter(route => selectedRouteDict[route.rid])
       .reduce((layers, route) => [
         ...layers,
         this.state.showStops

--- a/src/Map.jsx
+++ b/src/Map.jsx
@@ -269,7 +269,7 @@ class Map extends Component {
 
     const selectedRouteNames = new Set();
     this.selectedRoutes
-      .forEach(route => selectedRouteNames.add(route.properties.name));
+      .forEach(route => selectedRouteNames.add(route.properties.name.replace(/[.,/#!$%^&*;:{}=\-_`~()]/g, '')));
     const routeLayers = (routes || [])
       .filter(route => selectedRouteNames.has(route.rid))
       .reduce((layers, route) => [

--- a/src/Map.jsx
+++ b/src/Map.jsx
@@ -173,7 +173,6 @@ class Map extends Component {
     }
     if (stops.length === 0
       || (stops.length === 1 && !stops[0].equals(stopInfo))) {
-      console.log(`Stop Sid: ${stopInfo.sid}`);
       stops.push(stopInfo);
     }
     if (stops.length === 2) {
@@ -273,7 +272,6 @@ class Map extends Component {
       KT: 'K/T',
     };
     // eslint-disable-next-line no-console
-    console.log(selectedRouteNames);
     const routeLayers = (routes || [])
       .filter(route => selectedRouteNames.has(routeNameMapping[route.rid] || route.rid))
       .reduce((layers, route) => [
@@ -288,7 +286,6 @@ class Map extends Component {
         ...getVehicleMarkersLayer(route, info => this.displayVehicleInfo(info)),
       ], []);
     // eslint-disable-next-line no-console
-    console.log(routeLayers);
     routeLayers.push(getRoutesLayer(geojson));
     return (
       <ReactMapGL


### PR DESCRIPTION
Creates a new object and "maps" the `selectedRouteNames` as keys and objects into it, with an exception for K/T. Then, when filtering, instead of calling `has()` on a Set, we check if the `rid` key exists in the object.