### PR TITLE
Isolates DateTimePicker button color on hover, and removes box shadow when active

### DIFF
--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -82,3 +82,16 @@ body {
 .routes-header > .rw-datetime-picker > .rw-widget-picker > .rw-select > button {
   border-right: 1px solid #CCC;
 }
+
+.routes-header > .rw-datetime-picker > .rw-widget-picker > .rw-select-bordered:hover {
+  background-color: #FFF;
+}
+
+.routes-header > .rw-datetime-picker > .rw-widget-picker > .rw-select-bordered:active {
+  box-shadow: none;
+}
+
+
+.routes-header > .rw-datetime-picker > .rw-widget-picker > .rw-select-bordered > .rw-btn:hover {
+  background-color: #E6E6E6;
+}


### PR DESCRIPTION
<img width="1680" alt="screen shot 2018-12-19 at 8 56 12 pm" src="https://user-images.githubusercontent.com/25068419/50264678-8a4e9f00-03d0-11e9-87fc-65d3dce1eda4.png">

Couldn't find a CSS solution for the icons when they change opacity in tandem when either is hovered over, but it seems more like a "feature" of the package than a bug.