### PR TITLE
Fix control panel padding

### DIFF
--- a/src/ControlPanel.jsx
+++ b/src/ControlPanel.jsx
@@ -88,7 +88,7 @@ class ControlPanel extends Component {
         <div className="routes-header">
           <h3>Routes</h3>
         </div>
-        <ul className="route-checkboxes">
+        <ul className="list-group">
           {sortedRoutes.map(route => (
             <Checkbox
               route={route}

--- a/src/Map.jsx
+++ b/src/Map.jsx
@@ -167,11 +167,11 @@ class Map extends Component {
     };
     this.setState({ geojson: newGeojson });
   }
-  
+
   toggleStops() {
     this.setState({ showStops: !this.state.showStops });
   }
-  
+
   renderMap() {
     const onViewportChange = viewport => this.setState({ viewport });
     const { trynState } = this.props.trynState || {};


### PR DESCRIPTION
- Change control panel style to `list-group` as to remove padding on its left (from https://github.com/trynmaps/opentransit-map/pull/67 where a css style that doesn't exist was used, which was noticed as the control panel moved to the right)
- Also remove trailing spaces to make linter happy (lines 170+174 from https://github.com/trynmaps/opentransit-map/pull/91)