### PR TITLE
87 - add a new city + ui support to select it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules
+build.zip
+build
 config.json
 src/config.json
 src/prodConfig.json

--- a/src/Cities.json
+++ b/src/Cities.json
@@ -1,9 +1,13 @@
 [{
 	"name": "San Francisco",
+	"agency": "muni",
+	"path": "muniRoutes.geo.json",
 	"latitude": 37.7853,
 	"longitude": -122.41669
 }, {
 	"name": "Toronto",
+	"agency": "ttc",
+	"path": "ttcRoutes.geo.json",
 	"latitude": 43.761539,
 	"longitude": -79.411079
 }]

--- a/src/Route.jsx
+++ b/src/Route.jsx
@@ -36,8 +36,8 @@ const MUNI_COLOR = [
 
 /* changes color of selected stop along a route */
 function selectedStopColor(stop, selectedStops) {
-  const selectedStopsIds
-  = selectedStops.map(currentstop => currentstop.sid);
+  const selectedStopsIds =
+    selectedStops.map(currentstop => currentstop.sid);
   if (selectedStopsIds.includes(stop.sid)) {
     return [0, 255, 0];
   }
@@ -45,7 +45,6 @@ function selectedStopColor(stop, selectedStops) {
 }
 export function getStopMarkersLayer(route, getStopInfo, selectedStops) {
   /* returns new DeckGL Icon Layer displaying all stops on given routes */
-
   // Push stop markers into data array
   const data = route.stops.map(stop => ({
     position: [stop.lon, stop.lat],
@@ -53,7 +52,6 @@ export function getStopMarkersLayer(route, getStopInfo, selectedStops) {
     size: 72,
     color: selectedStopColor(stop, selectedStops),
   }));
-
   return (new IconLayer({
     id: 'stop-icon-layer',
     data,

--- a/src/envEndpoints.json
+++ b/src/envEndpoints.json
@@ -1,5 +1,5 @@
 {
   "LOCAL_API_URL": "http://localhost:4000/graphql",
   "PROD_API_URL": "https://06o8rkohub.execute-api.us-west-2.amazonaws.com/dev/graphql",
-  "USE_PROD_ENDPOINT": true
+  "USE_PROD_ENDPOINT": true 
 }

--- a/src/sortingHelper.js
+++ b/src/sortingHelper.js
@@ -1,0 +1,33 @@
+/*
+Sort by putting letters before numbers and treat number strings as integers.
+Calling Array.prototype.sort() without a compare function sorts elements as
+strings by Unicode code point order, e.g. [2, 12, 13, 9, 1, 27].sort() returns
+[1, 12, 13, 2, 27, 9]
+*/
+function sortAlphaNumeric(a, b) {
+  const notAlpha = /[^a-zA-Z]/g;
+
+  const aRoute = a.properties.name;
+  const bRoute = b.properties.name;
+  const aInteger = parseInt(aRoute, 10);
+  const bInteger = parseInt(bRoute, 10);
+  const aAlpha = aRoute.replace(notAlpha, '');
+  const bAlpha = bRoute.replace(notAlpha, '');
+
+  // special case for K/T and K-OWL
+  if (aRoute === 'K/T' && bRoute === 'K-OWL') return -1;
+  if (aRoute === 'K-OWL' && bRoute === 'K/T') return 1;
+
+  if (Number.isNaN(aInteger) && Number.isNaN(bInteger)) {
+    return aAlpha < bAlpha ? -1 : 1;
+  } else if (Number.isNaN(aInteger)) {
+    return -1;
+  } else if (Number.isNaN(bInteger)) {
+    return 1;
+  } else if (aInteger === bInteger) {
+    return aAlpha < bAlpha ? -1 : 1;
+  }
+  return aInteger - bInteger;
+}
+
+export default sortAlphaNumeric;


### PR DESCRIPTION
Allows users to choose a different city, which changes the routes shown
in the control panel, changes the agency set in API requests, clears
routes/stops already drawn, moves the map, and uses a different geojson
file.

Cities are set in cities.json, and so new cities can now easily be
added. Note that the API currently only supports Muni and the
Toronto Transit Commission.

## Link to Issue:
(also, start the PR title with the issue #)
https://github.com/trynmaps/opentransit-map/issues/87

## Description
What code changes did you make? Also say why you needed to make them.

- ControlPanel: added the dropdown
- Map: added the clear selectedRoutes function (needed to clear everything drawn when changing cities).

## Testing
We don't have any automated testing at the moment; this is to ensure that we don't break things until we have automated tests.

- Ensured vehicles and routes loaded when changing between cities.
- Also ensured all routes/vehicles/stops were cleared whenever the city was changed.

The map loads [Y/N] Y
Selecting a route shows it on the map, along with its vehicles [Y/N] Y
Changing the time to an hour in the past results in the vehicles changing their locations [Y/N] Y

Does the web-app look the same as the master branch? [Y/N]
If not, attach a screenshot of how it looks.

- Same but with a dropdown for choosing a city.
