### PR TITLE
104 - add different color for express ttc routes

### DIFF
--- a/src/helpers/Route.jsx
+++ b/src/helpers/Route.jsx
@@ -17,6 +17,7 @@ const BUS_ICON_MAPPING = {
   },
 };
 
+const TTC_EXPRESS_COLOR = [0, 165, 79];
 /* https://en.wikipedia.org/wiki/Template:MUNI_color */
 const MUNI_COLOR = [
   { line: 'E', color: [102, 102, 102] },
@@ -95,6 +96,10 @@ function lineToColor(line) {
   const checkedLine = MUNI_COLOR.filter(e => e.line === line);
   if (checkedLine.length > 0) {
     return checkedLine[0].color;
+  }
+  // TODO - make color selection for routes agency-scoped
+  if (line >= 900) {
+    return TTC_EXPRESS_COLOR;
   }
   return MUNI_COLOR[MUNI_COLOR.length - 1].color;
 }


### PR DESCRIPTION
## Link to Issue:
(also, start the PR title with the issue #)
https://github.com/trynmaps/opentransit-map/issues/104

## Description
What code changes did you make? Also say why you needed to make them.
- changed the getLineColor function

## Testing
We don't have any automated testing at the moment; this is to ensure that we don't break things until we have automated tests.
- TTC express routes are colored green, as intended
The map loads [Y/N] Y
Selecting a route shows it on the map, along with its vehicles [Y/N] Y
Changing the time to an hour in the past results in the vehicles changing their locations [Y/N] Y

Does the web-app look the same as the master branch? [Y/N] Y
If not, attach a screenshot of how it looks.
